### PR TITLE
Add the schema in LDIF format

### DIFF
--- a/postfix.ldif
+++ b/postfix.ldif
@@ -1,0 +1,15 @@
+# Schema as required by Postfix: http://www.postfix.org/LDAP_README.html
+
+dn: cn=postfix,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: postfix
+olcAttributeTypes: {0}( 1.3.6.1.4.1.4203.666.1.200 NAME 'mailacceptinggenera
+ lid' DESC 'Postfix mail local address alias attribute' EQUALITY caseIgnoreM
+ atch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{
+ 1024} )
+olcAttributeTypes: {1}( 1.3.6.1.4.1.4203.666.1.201 NAME 'maildrop' DESC 'Pos
+ tfix mail final destination attribute' EQUALITY caseIgnoreMatch SUBSTR case
+ IgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024} )
+olcObjectClasses: {0}( 1.3.6.1.4.1.4203.666.1.100 NAME 'postfixUser' DESC 'P
+ ostfix mail user class' SUP top AUXILIARY MAY ( mailacceptinggeneralid $ ma
+ ildrop ) )


### PR DESCRIPTION
The LDIF file is produced from postfix.schema with the following commands:

``` bash
mkdir slapd.d
echo "include $PWD/postfix.schema" > slapd.conf
slapcat -f slapd.conf -F slapd.d -n0 -l postfix.ldif -H ldap:///cn={0}postfix,cn=schema,cn=config
sed -i -e '/CRC32/d ; s/{0}postfix/postfix/ ; /structuralObjectClass/,$d' postfix.ldif
rm -rf slapd.d
rm slapd.conf
```
