### PR TITLE
Switch to Debian registered OID

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ mailacceptinggeneralid: m.mustermann
 mailacceptinggeneralid: bugs
 maildrop: mmu
 ````
-Please note that the OID used in the schema here is an OID of the type *Experimental OpenLDAP*, see also http://www.oid-info.com/get/1.3.6.1.4.1.4203.666 .
+Please note that the original OID used in the schema here was an OID of the type *Experimental OpenLDAP*, see also http://www.oid-info.com/get/1.3.6.1.4.1.4203.666 .
+
+The original  schema can be found on various sources on the internet. The previous version was copied from http://fossies.org/linux/group-e/doc/examples/LDAP/schema/postfix.schema and has been slightly modifiedr, and again for new OID.
+
+This now uses an OID from the Debian tree, see https://dsa.debian.org/iana/ and  http://www.oid-info.com/get/1.3.6.1.4.1.9586.100.8
+
+It uses .1 for attribute types and .2 for objectclasses
 
 
-The schema can be found on various sources on the internet. The current version was copied from http://fossies.org/linux/group-e/doc/examples/LDAP/schema/postfix.schema and has been slightly modified.
+

--- a/postfix.schema
+++ b/postfix.schema
@@ -1,7 +1,7 @@
 # Schema as required by Postfix: http://www.postfix.org/LDAP_README.html
 
 attributetype (
-  1.3.6.1.4.1.4203.666.1.200
+  1.3.6.1.4.1.9586.100.8.1.1
   NAME 'mailacceptinggeneralid'
   DESC 'Postfix mail local address alias attribute'
   EQUALITY caseIgnoreMatch
@@ -10,7 +10,7 @@ attributetype (
   )
 
 attributetype (
-  1.3.6.1.4.1.4203.666.1.201
+  1.3.6.1.4.1.9586.100.8.1.2
   NAME 'maildrop'
   DESC 'Postfix mail final destination attribute'
   EQUALITY caseIgnoreMatch
@@ -19,7 +19,7 @@ attributetype (
   )
 
 objectclass (
-  1.3.6.1.4.1.4203.666.1.100
+  1.3.6.1.4.1.9586.100.8.2.1
   NAME 'postfixUser'
   DESC 'Postfix mail user class'
   SUP top


### PR DESCRIPTION
Switching away from OpenLDAP experimental OID will avoid the possibility of a clash - see issue #2 